### PR TITLE
Changed name of the ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Tracking Code For Google Analytics
 
-Tracking Code For Google Analytics is a simple, lightweight WordPress plugin for inserting your Google Analytics tracking code. The plugin does one thing and one thing only; prints the standard Google Analytics tacking script to the `<head>` of your website. To insert your tracking  code ID, navigate to Settings > General and then scroll to the bottom of the page.
+Tracking Code For Google Analytics is a simple, lightweight WordPress plugin for inserting your Google Analytics tracking code. The plugin does one thing and one thing only; prints the standard Google Analytics tacking script to the `<head>` of your website. To insert your measurement ID, navigate to Settings > General and then scroll to the bottom of the page.
 
 ### Getting Started
 
 1. Upload `tracking-code-for-google-analytics` to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. Navigate to Settings > General > scroll to the bottom of the page
-4. Insert your tracking code ID
+4. Insert your measurement ID
 5. Save your changes
 
 ### Composer
@@ -16,20 +16,20 @@ Tracking Code For Google Analytics is a simple, lightweight WordPress plugin for
 
 ### Filters
 
-If you want to set the tracking code ID without using the wp-admin user interface, use the filter below.
+If you want to set the measurement ID without using the wp-admin user interface, use the filter below.
 
 ```php
 add_filter(
 	'tracking_code_for_google_analytics_id',
 	/**
-	 * Set Google Analytics tracking code ID.
+	 * Set Google Analytics measurement ID.
 	 *
-	 * @param string $tracking_code_id Tracking code ID.
+	 * @param string $measurement_id Measurement ID.
 	 *
 	 * @return string
 	 */
-	function ( $tracking_code_id ) {
-	    return 'UA-7654321';
+	function ( $measurement_id ) {
+		return 'UA-7654321';
 	}
 );
 ```

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -10,9 +10,9 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-add_action( 'admin_init', 'tracking_code_for_google_analytics_add_settings_field' );
+add_action( 'admin_init', 'tracking_code_for_google_analytics_add_settings_field', 10, 0 );
 /**
- * Register the settings field for the tracking code ID.
+ * Register the settings field for the measurement ID.
  *
  * @return void
  * @since 1.0.0
@@ -28,7 +28,7 @@ function tracking_code_for_google_analytics_add_settings_field() {
 			'id'          => 'tracking-code-for-google-analytics',
 			'name'        => 'tracking_code_for_google_analytics',
 			'value'       => get_option( 'tracking_code_for_google_analytics', '' ),
-			'description' => esc_html__( 'Enter your Google Analytics tracking code ID eg. UA-1234567', 'tracking-code-for-google-analytics' ),
+			'description' => esc_html__( 'Enter your Google Analytics measurement ID eg. UA-1234567', 'tracking-code-for-google-analytics' ),
 		)
 	);
 
@@ -37,7 +37,7 @@ function tracking_code_for_google_analytics_add_settings_field() {
 		'tracking_code_for_google_analytics',
 		array(
 			'type'              => 'string',
-			'description'       => esc_html__( 'Google Analytics tracking code ID', 'tracking-code-for-google-analytics' ),
+			'description'       => esc_html__( 'Google Analytics measurement ID', 'tracking-code-for-google-analytics' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => true,
 			'default'           => '',
@@ -46,7 +46,7 @@ function tracking_code_for_google_analytics_add_settings_field() {
 }
 
 /**
- * Text field for tracking code ID.
+ * Text field for measurement ID.
  *
  * @param array $args The field settings.
  * @return void

--- a/inc/public.php
+++ b/inc/public.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-add_action( 'wp_head', 'tracking_code_for_google_analytics_do_the_script', 1 );
+add_action( 'wp_head', 'tracking_code_for_google_analytics_do_the_script', 1, 0 );
 /**
  * Output the tracking code snippet to the frontend.
  *
@@ -19,29 +19,31 @@ add_action( 'wp_head', 'tracking_code_for_google_analytics_do_the_script', 1 );
  */
 function tracking_code_for_google_analytics_do_the_script() {
 	/**
-	 * Filter the tracking_code_id variable to support other methods of setting this value.
+	 * Filter the measurement_id variable to support other methods of setting this value.
 	 *
-	 * @param string $tracking_code_id The Google Analytics tracking code ID.
+	 * @param string $measurement_id The Google Analytics tracking code ID.
 	 * @return string
 	 * @since 1.0.0
 	 */
-	$tracking_code_id = apply_filters( 'tracking_code_for_google_analytics_id', get_option( 'tracking_code_for_google_analytics', '' ) );
+	$measurement_id = apply_filters( 'tracking_code_for_google_analytics_id', get_option( 'tracking_code_for_google_analytics', '' ) );
 
-	if ( ! empty( $tracking_code_id ) ) {
-		printf(
-            // phpcs:disable
-			'
-            <!-- Global site tag (gtag.js) - Google Analytics -->
-            <script async src="https://www.googletagmanager.com/gtag/js?id=%1$s"></script>
-            <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag("js", new Date());
-            gtag("config", "%1$s");
-            </script>
-            ',
-            // phpcs:enable
-			esc_attr( $tracking_code_id )
-		);
-	}
+	if ( '' === $tracking_code_id ) {
+		return;
+    }
+
+	printf(
+		// phpcs:disable
+		'
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=%1$s"></script>
+		<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag("js", new Date());
+		gtag("config", "%1$s");
+		</script>
+		',
+		// phpcs:enable
+		esc_attr( $measurement_id )
+	);
 }

--- a/inc/public.php
+++ b/inc/public.php
@@ -27,9 +27,9 @@ function tracking_code_for_google_analytics_do_the_script() {
 	 */
 	$measurement_id = apply_filters( 'tracking_code_for_google_analytics_id', get_option( 'tracking_code_for_google_analytics', '' ) );
 
-	if ( '' === $tracking_code_id ) {
+	if ( '' === $measurement_id ) {
 		return;
-    }
+	}
 
 	printf(
 		// phpcs:disable


### PR DESCRIPTION
- was called "tracking id"
- was not called "tracking code ID"
- now called  "measurement ID": https://developers.google.com/analytics/devguides/collection/gtagjs

This PR consistently names it "measurement ID".
